### PR TITLE
fix: QTime -> QElapsedTimer

### DIFF
--- a/automator.cpp
+++ b/automator.cpp
@@ -2,7 +2,7 @@
 #include <QEventLoop>
 #include <QTimer>
 #include <QQuickItem>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QTest>
 #include <QSignalSpy>
 #include "automator.h"
@@ -151,7 +151,7 @@ QObjectList Automator::findObjects(QString objectName)
 
 bool Automator::waitExists(QString objectName, int timeout)
 {
-    QTime time;
+    QElapsedTimer time;
     time.start();
 
     while (true) {
@@ -174,7 +174,7 @@ bool Automator::waitExists(QString objectName, int timeout)
 bool Automator::waitUntil(QObject *object, QString property, QVariant value, int timeout)
 {
     QVariant objectValue = object->property(property.toLocal8Bit().constData());
-    QTime time;
+    QElapsedTimer time;
     time.start();
 
     while (objectValue != value) {
@@ -213,7 +213,7 @@ bool Automator::waitUntilSignal(QObject *object, const char *signal, int timeout
 
 bool Automator::waitUntil(QString objectName, QString property, QVariant value, int timeout)
 {
-    QTime time;
+    QElapsedTimer time;
     time.start();
 
     QObject* object = findObject(objectName);

--- a/automator.h
+++ b/automator.h
@@ -4,7 +4,7 @@
 #include <QPointer>
 #include <QQuickItem>
 #include <QPointF>
-#include <QTime>
+#include <QElapsedTimer>
 
 /// Automator provides an interface to manipulate UI object loaded by QQmlApplicationEngine
 
@@ -51,7 +51,7 @@ public:
 
     template <typename Functor>
     bool waitUntil(Functor functor, int timeout = -1) {
-        QTime time;
+        QElapsedTimer time;
         time.start();
 
         while (!functor()) {

--- a/tests/testableunittests/testableunittests.cpp
+++ b/tests/testableunittests/testableunittests.cpp
@@ -1,6 +1,7 @@
 #include <QtCore>
 #include <QTest>
 #include <QQmlApplicationEngine>
+#include <QElapsedTimer>
 #include <Automator>
 #include <TestRunner>
 #include "testableunittests.h"
@@ -61,7 +62,7 @@ void TestableUnitTests::automatorObtainSingletonObject()
 void TestableUnitTests::automatorWaitUntilSignal()
 {
     QTimer * timer = new QTimer(this);
-    QTime time;
+    QElapsedTimer time;
     time.start();
 
     timer->setInterval(500);


### PR DESCRIPTION
Usage of QTime::start/elapsed is deprecated, so as Qt documentation
suggests use QElapsedTimer